### PR TITLE
fix: correct course name for HBA27C

### DIFF
--- a/src/programmes/bba.ts
+++ b/src/programmes/bba.ts
@@ -191,7 +191,7 @@ const subjects = [
   },
   {
     ectsCode: 'HBA27C',
-    subjectName: 'Research Methods 3',
+    subjectName: 'Statistical Modelling',
     teachers: ['M.Meulders'],
   },
   {


### PR DESCRIPTION
The course page shows that HBA27C contains 'Statistical Modelling' as its main 4 ECTS component, not 'Research Methods 3' as previously labeled.

Fixes #8

Generated with [Claude Code](https://claude.ai/code)