### PR TITLE
Add HBA86B (Quantitative Research Project) to BBA programme data

### DIFF
--- a/src/programmes/bba.ts
+++ b/src/programmes/bba.ts
@@ -340,6 +340,11 @@ const subjects = [
     teachers: ['K.De Bruyne'],
   },
   {
+    ectsCode: 'HBA86B',
+    subjectName: 'Quantitative Research Project',
+    teachers: ['M.Meulders'],
+  },
+  {
     ectsCode: 'HBH85E',
     subjectName: 'Management humain (UC Louvain)',
     teachers: ['T.Verbeke'],


### PR DESCRIPTION
Fixes issue where HBA86b appeared as just "Quantitative" without additional information. Added full course name and teacher information extracted from the KU Leuven Onderwijsaanbod syllabus page.

- Course: Quantitative Research Project
- Teacher: M.Meulders
- Credits: 2 ECTS

Resolves #10

Generated with [Claude Code](https://claude.ai/code)